### PR TITLE
fix(compose): Fix the case sensitive file name issue on Ubuntu

### DIFF
--- a/nodegoat-app/docker-compose.yml
+++ b/nodegoat-app/docker-compose.yml
@@ -3,6 +3,6 @@ services:
   nodegoat:
     build:
       context: ##THIS_DIR##/.
-      dockerfile: Dockerfile
+      dockerfile: DockerFile
     ports:
      - 4000


### PR DESCRIPTION
Example test fails to run on ubuntu due to docker file name case sensitivity issue. This PR will fix it